### PR TITLE
Add option to disable context menu

### DIFF
--- a/attachmediastream.js
+++ b/attachmediastream.js
@@ -6,7 +6,8 @@ module.exports = function (stream, el, options) {
         autoplay: true,
         mirror: false,
         muted: false,
-        audio: false
+        audio: false,
+        disableContextMenu: false
     };
 
     if (options) {
@@ -19,6 +20,12 @@ module.exports = function (stream, el, options) {
         element = document.createElement(opts.audio ? 'audio' : 'video');
     } else if (element.tagName.toLowerCase() === 'audio') {
         opts.audio = true;
+    }
+
+    if (opts.disableContextMenu) {
+        element.oncontextmenu = function (e) {
+            e.preventDefault();
+        };
     }
 
     if (opts.autoplay) element.autoplay = 'autoplay';


### PR DESCRIPTION
Passing `disableContextMenu: true` in the options will auto-disable the
right click context menu on the video or audio element.