### PR TITLE
Reverse the order of attachment methods

### DIFF
--- a/attachmediastream.js
+++ b/attachmediastream.js
@@ -30,14 +30,12 @@ module.exports = function (stream, el, options) {
         });
     }
 
-    // this first one should work most everywhere now
-    // but we have a few fallbacks just in case.
-    if (URL && URL.createObjectURL) {
-        element.src = URL.createObjectURL(stream);
-    } else if (element.srcObject) {
+    if (typeof element.srcObject !== 'undefined') {
         element.srcObject = stream;
-    } else if (element.mozSrcObject) {
+    } else if (typeof element.mozSrcObject !== 'undefined') {
         element.mozSrcObject = stream;
+    } else if (URL && URL.createObjectURL) {
+        element.src = URL.createObjectURL(stream);
     } else {
         return false;
     }


### PR DESCRIPTION
The preferred method is supposed to be `srcObject`, not `URL.createObjectURL`.