### PR TITLE
Allow resetting of mute and mirror options on the element

### DIFF
--- a/attachmediastream.js
+++ b/attachmediastream.js
@@ -30,11 +30,11 @@ module.exports = function (stream, el, options) {
     }
 
     if (opts.autoplay) element.autoplay = 'autoplay';
-    if (opts.muted) element.muted = true;
-    if (!opts.audio && opts.mirror) {
+    element.muted = !!opts.muted;
+    if (!opts.audio) {
         ['', 'moz', 'webkit', 'o', 'ms'].forEach(function (prefix) {
             var styleName = prefix ? prefix + 'Transform' : 'transform';
-            element.style[styleName] = 'scaleX(-1)';
+            element.style[styleName] = opts.mirror ? 'scaleX(-1)' : 'scaleX(1)';
         });
     }
 


### PR DESCRIPTION
Use case here is if you use attachMediaStream on a video element, then call it again on the same element with different options the element remains unchanged.

Real world example: we are using a single video element vidEl. UserA joins a video conference and is the only person in the conference. We render UserA's outgoing video stream to vidEl with `{muted: true, mirror: true}`. When UserB joins the conference we replace the video stream on vidEl with UserB's incoming video and provide the options `{muted: false, mirror: false}`. The stream feed changes but it's still muted and mirrored. This fixes that issue.